### PR TITLE
Add SVG export for 2D plots (v1.4.0).

### DIFF
--- a/docs/pages/plots.rst
+++ b/docs/pages/plots.rst
@@ -14,6 +14,33 @@ All plots inherits from the Window base class. This class should not be used in 
     .. automethod:: kaxe.AttrMap.help
 
 
+Saving plots
+------------
+
+All 2D plot and chart windows support PNG (default) and SVG export via :py:meth:`kaxe.Window.save`.
+
+.. code-block:: python
+
+   plt.save("plot.png")
+   plt.save("plot.svg")
+
+When the filename has no extension, pass ``format`` explicitly (for example when writing to ``BytesIO``):
+
+.. code-block:: python
+
+   from io import BytesIO
+
+   buf = BytesIO()
+   plt.save(buf, format="svg")
+
+SVG export produces a self-contained vector file: curves, axes, and labels are vector graphics.
+Math labels use `fondi <https://github.com/valteryde/fondi>`_ with embedded New Computer Modern fonts.
+PNG and SVG can be saved from the same plot; saving SVG does not affect a cached PNG.
+
+.. note::
+   SVG export is supported for 2D plots and charts only. :class:`kaxe.Plot3D` and :class:`kaxe.Grid` still save PNG.
+
+
 Classical Plot
 --------------
 .. autoclass:: kaxe.Plot

--- a/docs/pages/start.rst
+++ b/docs/pages/start.rst
@@ -24,6 +24,18 @@ To get started with Kaxe, you can create a simple plot:
    plt = kaxe.Plot()
    plt.show()
 
+Saving
+------
+
+Save a plot as PNG (default) or SVG:
+
+.. code-block:: python
+
+   plt.save("myplot.png")
+   plt.save("myplot.svg")
+
+Open SVG files in a browser or vector editor (Inkscape, Illustrator). The built-in editor XML view is source, not a rendered preview.
+
 Kaxe has theese plots
 
 * :class:`kaxe.Plot`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
   "pillow",
-  "fondi @ git+https://github.com/valteryde/fondi.git",
+  "fondi>=0.2.0",
   "sympy",
   "scipy",
   "openpyxl",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kaxe"
-version = "1.3.5"
+version = "1.4.0"
 authors = [
   { name="Valter Yde Daugberg", email="valteryde@hotmail.com" },
 ]
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
   "pillow",
-  "fondi",
+  "fondi @ git+https://github.com/valteryde/fondi.git",
   "sympy",
   "scipy",
   "openpyxl",

--- a/src/kaxe/core/shapes.py
+++ b/src/kaxe/core/shapes.py
@@ -7,6 +7,7 @@ from PIL import Image, ImageDraw
 from .styles import *
 from .helper import *
 from .line import drawLineOnPillowImage
+from .svg import SvgDocument
 import os
 import numpy as np
 import logging
@@ -81,13 +82,19 @@ class Shape:
 
 
     def draw(self, *args, **kwargs):
-        if self.__hidden__:return
-
+        if self.__hidden__:
+            return
+        if args and isinstance(args[0], SvgDocument):
+            self.drawSvg(args[0])
+            return
         try:
             if self.engine == engine.PILLOW:
                 self.drawPillow(*args, **kwargs)
         except ZeroDivisionError:
             logging.critical('No man')
+
+    def drawSvg(self, doc: SvgDocument):
+        pass
 
     
     def hide(self):
@@ -139,6 +146,17 @@ class Rectangle(Shape):
     
     def getBoundingBox(self):
         return [self.width, self.height]
+
+    def drawSvg(self, doc: SvgDocument):
+        doc.add_rect(
+            self.x,
+            self.y,
+            self.width,
+            self.height,
+            self.color,
+            outline_width=self.outlineWidth,
+            outline_color=self.outlineColor,
+        )
 
 
 class Line(Shape):
@@ -222,6 +240,9 @@ class Line(Shape):
         return self.drawPillowNew(surface)
         return self.drawPillowSimple(surface)
 
+    def drawSvg(self, doc: SvgDocument):
+        doc.add_line(self.x0, self.y0, self.x1, self.y1, self.color, self.thickness)
+
 
 class Circle(Shape):
 
@@ -268,6 +289,20 @@ class Circle(Shape):
     def getBoundingBox(self): # returns 
         return [self.radius*2, self.radius*2]
 
+    def drawSvg(self, doc: SvgDocument):
+        cx, cy = self.x, self.y
+        if self.cornerAlign:
+            cx = self.x + self.radius
+            cy = self.y - self.radius
+        doc.add_circle(
+            cx,
+            cy,
+            self.radius,
+            self.color,
+            fill=self.fill,
+            stroke_width=self.width,
+        )
+
 
 class ImageShape(Shape):
     def __init__(self, file:Union[str, Image.Image], x:int, y:int, batch:Batch=None):
@@ -299,6 +334,9 @@ class ImageShape(Shape):
     def drawPillow(self, surface):
         return blitImageToSurface(surface, self.img, (self.x, flipHorizontal(surface, self.y)[0] - self.img.height))
 
+    def drawSvg(self, doc: SvgDocument):
+        doc.add_image(self.img, self.x, self.y)
+
 
 class ImageArrayShape(Shape):
     def __init__(self, imarr:np.ndarray, x:int, y:int, batch:Batch=None):
@@ -321,6 +359,9 @@ class ImageArrayShape(Shape):
 
     def drawPillow(self, surface):
         return blitImageToSurface(surface, self.img, (self.x, flipHorizontal(surface, self.y)[0] - self.img.height))
+
+    def drawSvg(self, doc: SvgDocument):
+        doc.add_image(self.img, self.x, self.y)
 
 
 class Triangle(Shape):
@@ -360,6 +401,9 @@ class Triangle(Shape):
     
     def getBoundingBox(self):
         return [self.width, self.height]
+
+    def drawSvg(self, doc: SvgDocument):
+        doc.add_polygon([self.p1, self.p2, self.p3], self.color)
 
 
     def push(self, x, y):
@@ -408,6 +452,10 @@ class Polygon(Shape):
     
     def getBoundingBox(self):
         return [self.width, self.height]
+
+    def drawSvg(self, doc: SvgDocument):
+        absolute = [(px + self.x, py + self.y) for px, py in self.points]
+        doc.add_polygon(absolute, self.color)
 
 
 
@@ -496,6 +544,19 @@ class LineSegment(Shape):
             except IndexError:
                 pass
 
+    def drawSvg(self, doc: SvgDocument):
+        if len(self.points) <= 1:
+            return
+        shifted = [(x + self.offset[0], y + self.offset[1]) for x, y in self.points]
+        doc.add_polyline(
+            shifted,
+            self.color,
+            self.thickness,
+            dotted=self.dotted,
+            dotted_dist=self.dottedDist,
+            dashed=self.dashed,
+            dashed_dist=self.dashedDist,
+        )
 
 
 class Arc(Shape):
@@ -533,6 +594,18 @@ class Arc(Shape):
         draw.pieslice((0,0, doubleRadius, doubleRadius), -self.angle-self.phaseshift, -self.phaseshift, fill=self.color)
 
         blitImageToSurface(surface, img, (self.center[0]-self.radius, self.center[1]-self.radius))
+
+    def drawSvg(self, doc: SvgDocument):
+        start = -self.angle - self.phaseshift
+        end = -self.phaseshift
+        doc.add_arc_wedge(
+            self.center[0],
+            self.center[1],
+            self.radius,
+            start,
+            end,
+            self.color,
+        )
 
 
 # NAMESPACE

--- a/src/kaxe/core/svg.py
+++ b/src/kaxe/core/svg.py
@@ -6,6 +6,7 @@ import base64
 import copy
 import io
 import math
+import os
 import xml.etree.ElementTree as ET
 from typing import Any, Optional, Union
 
@@ -185,8 +186,7 @@ class SvgDocument:
             return
 
         if dotted:
-            for x, y in points:
-                self.add_circle(x, y, width, color, fill=True)
+            self._add_dotted_polyline(points, color, width, dotted_dist)
             return
 
         svg_points = [(x, self.flip_y(y)) for x, y in points]
@@ -205,6 +205,20 @@ class SvgDocument:
         }
         _apply_color(attribs, color, stroke=True)
         self.add_element("polyline", attribs)
+
+    def _add_dotted_polyline(
+        self,
+        points: list[tuple[float, float]],
+        color: tuple,
+        width: float,
+        dot_dist: float,
+    ) -> None:
+        last = points[0]
+        for point in points[1:]:
+            dist = math.hypot(point[0] - last[0], point[1] - last[1])
+            if dist > dot_dist:
+                last = point
+                self.add_circle(last[0], last[1], width, color, fill=True)
 
     def _add_dashed_polyline(
         self,
@@ -352,7 +366,12 @@ class SvgDocument:
         return '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n' + body
 
 
-def infer_format(fname: Union[str, Any], format: Optional[str] = None) -> str:
+def is_file_path(fname: Any) -> bool:
+    """Return True when fname is a filesystem path (str or os.PathLike)."""
+    return isinstance(fname, (str, os.PathLike))
+
+
+def infer_format(fname: Union[str, os.PathLike, Any], format: Optional[str] = None) -> str:
     """Infer save format from explicit format, file extension, or default to png."""
     if format is not None:
         fmt = format.lower().lstrip(".")
@@ -360,8 +379,8 @@ def infer_format(fname: Union[str, Any], format: Optional[str] = None) -> str:
             return fmt
         raise ValueError(f"Unsupported format: {format}")
 
-    if isinstance(fname, str):
-        lower = fname.lower()
+    if is_file_path(fname):
+        lower = os.fspath(fname).lower()
         if lower.endswith(".svg"):
             return "svg"
         if lower.endswith(".png"):

--- a/src/kaxe/core/svg.py
+++ b/src/kaxe/core/svg.py
@@ -1,0 +1,370 @@
+"""SVG document builder for Kaxe vector export."""
+
+from __future__ import annotations
+
+import base64
+import copy
+import io
+import math
+import xml.etree.ElementTree as ET
+from typing import Any, Optional, Union
+
+from PIL import Image
+
+SVG_NS = "http://www.w3.org/2000/svg"
+XLINK_NS = "http://www.w3.org/1999/xlink"
+
+ET.register_namespace("", SVG_NS)
+ET.register_namespace("xlink", XLINK_NS)
+
+
+def flip_y(y: float, height: int) -> float:
+    """Convert kaxe y-up coordinate to SVG y-down."""
+    return height - y
+
+
+def rgba_to_svg(color: tuple) -> tuple[str, Optional[float]]:
+    """Return (fill/stroke color string, opacity or None)."""
+    r, g, b = int(color[0]), int(color[1]), int(color[2])
+    alpha = color[3] / 255.0 if len(color) > 3 else 1.0
+    opacity = None if alpha >= 1.0 else round(alpha, 4)
+    return f"rgb({r},{g},{b})", opacity
+
+
+def _apply_color(attribs: dict[str, str], color: tuple, *, stroke: bool = False) -> None:
+    value, opacity = rgba_to_svg(color)
+    key = "stroke" if stroke else "fill"
+    attribs[key] = value
+    if opacity is not None:
+        attribs["opacity"] = str(opacity)
+
+
+def pil_to_data_uri(img: Image.Image) -> str:
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
+
+class SvgDocument:
+    """Collects SVG elements and serializes to XML."""
+
+    def __init__(self, size: tuple[int, int]):
+        self._width, self._height = int(size[0]), int(size[1])
+        self._elements: list[ET.Element] = []
+        self._fondi_font_css: Optional[str] = None
+
+    @property
+    def height(self) -> int:
+        return self._height
+
+    @property
+    def width(self) -> int:
+        return self._width
+
+    def flip_y(self, y: float) -> float:
+        return flip_y(y, self._height)
+
+    def add_element(self, tag: str, attribs: dict[str, Any]) -> ET.Element:
+        el = ET.Element(
+            f"{{{SVG_NS}}}{tag}",
+            {k: str(v) for k, v in attribs.items() if v is not None},
+        )
+        self._elements.append(el)
+        return el
+
+    def add_rect(
+        self,
+        x: float,
+        y: float,
+        width: float,
+        height: float,
+        color: tuple,
+        *,
+        outline_width: int = 0,
+        outline_color: tuple = (0, 0, 0, 255),
+    ) -> None:
+        svg_y = self.flip_y(y) - height
+        if outline_width:
+            outer = {
+                "x": str(x),
+                "y": str(svg_y),
+                "width": str(width),
+                "height": str(height),
+            }
+            _apply_color(outer, outline_color)
+            self.add_element("rect", outer)
+            inset = outline_width
+            if 2 * inset < width and 2 * inset < height:
+                inner = {
+                    "x": str(x + inset),
+                    "y": str(svg_y + inset),
+                    "width": str(width - 2 * inset),
+                    "height": str(height - 2 * inset),
+                }
+                _apply_color(inner, color)
+                self.add_element("rect", inner)
+        else:
+            attribs = {
+                "x": str(x),
+                "y": str(svg_y),
+                "width": str(width),
+                "height": str(height),
+            }
+            _apply_color(attribs, color)
+            self.add_element("rect", attribs)
+
+    def add_line(
+        self,
+        x0: float,
+        y0: float,
+        x1: float,
+        y1: float,
+        color: tuple,
+        width: float = 1,
+    ) -> None:
+        if width <= 0:
+            return
+        attribs = {
+            "x1": str(x0),
+            "y1": str(self.flip_y(y0)),
+            "x2": str(x1),
+            "y2": str(self.flip_y(y1)),
+            "stroke-width": str(width),
+            "stroke-linecap": "round",
+        }
+        _apply_color(attribs, color, stroke=True)
+        attribs["fill"] = "none"
+        self.add_element("line", attribs)
+
+    def add_circle(
+        self,
+        cx: float,
+        cy: float,
+        radius: float,
+        color: tuple,
+        *,
+        fill: bool = True,
+        stroke_width: float = 5,
+    ) -> None:
+        attribs = {
+            "cx": str(cx),
+            "cy": str(self.flip_y(cy)),
+            "r": str(radius),
+        }
+        if fill:
+            _apply_color(attribs, color)
+        else:
+            attribs["fill"] = "none"
+            _apply_color(attribs, color, stroke=True)
+            attribs["stroke-width"] = str(stroke_width)
+        self.add_element("circle", attribs)
+
+    def add_polygon(self, points: list[tuple[float, float]], color: tuple) -> None:
+        if len(points) < 3:
+            return
+        parts = []
+        for x, y in points:
+            parts.append(f"{x},{self.flip_y(y)}")
+        attribs = {"points": " ".join(parts)}
+        _apply_color(attribs, color)
+        self.add_element("polygon", attribs)
+
+    def add_polyline(
+        self,
+        points: list[tuple[float, float]],
+        color: tuple,
+        width: float = 1,
+        *,
+        dotted: bool = False,
+        dotted_dist: float = 30,
+        dashed: bool = False,
+        dashed_dist: float = 30,
+    ) -> None:
+        if len(points) < 2:
+            return
+
+        if dotted:
+            for x, y in points:
+                self.add_circle(x, y, width, color, fill=True)
+            return
+
+        svg_points = [(x, self.flip_y(y)) for x, y in points]
+
+        if dashed:
+            self._add_dashed_polyline(points, color, width, dashed_dist)
+            return
+
+        parts = [f"{x},{y}" for x, y in svg_points]
+        attribs = {
+            "points": " ".join(parts),
+            "fill": "none",
+            "stroke-width": str(width),
+            "stroke-linecap": "round",
+            "stroke-linejoin": "round",
+        }
+        _apply_color(attribs, color, stroke=True)
+        self.add_element("polyline", attribs)
+
+    def _add_dashed_polyline(
+        self,
+        points: list[tuple[float, float]],
+        color: tuple,
+        width: float,
+        dash_dist: float,
+    ) -> None:
+        drew = False
+        last = points[0]
+        for point in points[1:]:
+            dist = math.hypot(point[0] - last[0], point[1] - last[1])
+            if dist > dash_dist:
+                if not drew:
+                    self.add_line(last[0], last[1], point[0], point[1], color, width)
+                    drew = True
+                else:
+                    drew = False
+                last = point
+
+    def add_arc_wedge(
+        self,
+        cx: float,
+        cy: float,
+        radius: float,
+        start_deg: float,
+        end_deg: float,
+        color: tuple,
+    ) -> None:
+        """Filled pie wedge; angles follow PIL pieslice convention (0=3 o'clock, CCW)."""
+        svg_cy = self.flip_y(cy)
+        start_rad = math.radians(start_deg)
+        end_rad = math.radians(end_deg)
+
+        x0 = cx + radius * math.cos(start_rad)
+        y0 = svg_cy - radius * math.sin(start_rad)
+        x1 = cx + radius * math.cos(end_rad)
+        y1 = svg_cy - radius * math.sin(end_rad)
+
+        delta = (end_deg - start_deg) % 360
+        large_arc = 1 if delta > 180 else 0
+        sweep = 1 if delta > 0 else 0
+
+        fill, opacity = rgba_to_svg(color)
+        d = (
+            f"M {cx},{svg_cy} L {x0},{y0} "
+            f"A {radius},{radius} 0 {large_arc},{sweep} {x1},{y1} Z"
+        )
+        attribs: dict[str, str] = {"d": d, "fill": fill}
+        if opacity is not None:
+            attribs["opacity"] = str(opacity)
+        self.add_element("path", attribs)
+
+    def add_image(
+        self,
+        img: Image.Image,
+        x: float,
+        y: float,
+        *,
+        y_coord: str = "bottom",
+        rotate: float = 0,
+        rotate_center: Optional[tuple[float, float]] = None,
+    ) -> None:
+        """Place an image; y is in kaxe coords (y-up). y_coord='bottom' or 'top'."""
+        href = pil_to_data_uri(img)
+        if y_coord == "top":
+            svg_top = self.flip_y(y)
+        else:
+            svg_top = self.flip_y(y) - img.height
+        attribs = {
+            "x": str(x),
+            "y": str(svg_top),
+            "width": str(img.width),
+            "height": str(img.height),
+            "href": href,
+            f"{{{XLINK_NS}}}href": href,
+        }
+        if rotate:
+            cx, cy = rotate_center or (x + img.width / 2, svg_top + img.height / 2)
+            attribs["transform"] = f"rotate({-rotate},{cx},{cy})"
+        self.add_element("image", attribs)
+
+    def _ensure_fondi_fonts(self) -> None:
+        if self._fondi_font_css is not None:
+            return
+        from fondi.backends.svg import _font_face_css
+
+        self._fondi_font_css = _font_face_css(embed_fonts=True, font_url_prefix="")
+
+    def add_fondi_scene(
+        self,
+        scene,
+        svg_left: float,
+        svg_top: float,
+        *,
+        rotate: float = 0,
+        rotate_center: Optional[tuple[float, float]] = None,
+    ) -> None:
+        """Embed a fondi scene (vector math text) at SVG top-left coordinates."""
+        from fondi.backends import render_svg
+
+        self._ensure_fondi_fonts()
+        h = max(scene.height, 0)
+
+        mini = render_svg(scene, embed_fonts=False)
+        if mini.startswith("<?"):
+            mini = mini.split("\n", 1)[1]
+        root = ET.fromstring(mini)
+        inner = root.find(f"{{{SVG_NS}}}g") or root.find("g")
+        if inner is None:
+            return
+
+        transform = f"translate({round(svg_left, 3)},{round(svg_top, 3)})"
+        if rotate:
+            cx, cy = rotate_center or (svg_left + scene.width / 2, svg_top + h / 2)
+            transform = (
+                f"translate({round(cx, 3)},{round(cy, 3)}) "
+                f"rotate({-rotate}) "
+                f"translate({round(-cx, 3)},{round(-cy, 3)}) "
+                f"{transform}"
+            )
+
+        group = ET.Element(f"{{{SVG_NS}}}g", {"transform": transform})
+        for child in list(inner):
+            group.append(copy.deepcopy(child))
+        self._elements.append(group)
+
+    def serialize(self) -> str:
+        root = ET.Element(
+            f"{{{SVG_NS}}}svg",
+            {
+                "version": "1.1",
+                "width": str(self._width),
+                "height": str(self._height),
+                "viewBox": f"0 0 {self._width} {self._height}",
+            },
+        )
+        if self._fondi_font_css is not None:
+            defs = ET.SubElement(root, f"{{{SVG_NS}}}defs")
+            style = ET.SubElement(defs, f"{{{SVG_NS}}}style")
+            style.text = self._fondi_font_css
+        for el in self._elements:
+            root.append(el)
+        body = ET.tostring(root, encoding="unicode")
+        return '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n' + body
+
+
+def infer_format(fname: Union[str, Any], format: Optional[str] = None) -> str:
+    """Infer save format from explicit format, file extension, or default to png."""
+    if format is not None:
+        fmt = format.lower().lstrip(".")
+        if fmt in ("svg", "png"):
+            return fmt
+        raise ValueError(f"Unsupported format: {format}")
+
+    if isinstance(fname, str):
+        lower = fname.lower()
+        if lower.endswith(".svg"):
+            return "svg"
+        if lower.endswith(".png"):
+            return "png"
+
+    return "png"

--- a/src/kaxe/core/text.py
+++ b/src/kaxe/core/text.py
@@ -7,7 +7,45 @@ from fondi import MathText
 import numpy as np
 
 textImageCache = {}
+mathtextCache = {}
 maxTextCacheSize = 100
+
+
+def _parse_kaxe_text(text: str) -> str:
+    """Translate kaxe $math$ syntax to fondi LaTeX string."""
+    res = ''
+    open_ = 0
+    word = ''
+    for char in text:
+        if char == '$' and open_:
+            open_ = False
+            continue
+        elif char == '$' and not open_:
+            open_ = True
+            if len(word) > 0:
+                res += '\\text{' + word + '}'
+            word = ''
+            continue
+
+        if open_:
+            res += char
+        else:
+            word += char
+
+    if len(word) > 0:
+        res += '\\text{' + word + '}'
+    return res
+
+
+def _get_mathtext(latex: str, fontSize: int, color: tuple) -> MathText:
+    key = str(latex), fontSize, tuple(color)
+    cached = mathtextCache.get(key)
+    if cached is not None:
+        return cached
+    mt = MathText(latex, fontSize, color)
+    mathtextCache[key] = mt
+    return mt
+
 
 class Text(Shape):
     
@@ -33,51 +71,21 @@ class Text(Shape):
         super().__init__()
         if batch: batch.add(self)
 
-        # translate str "$math$ + normaltext" to "math + \\text{normaltext}"
-        res = ''
-        open_ = 0
-        word = ''
-        for char in text:
-            if char == '$' and open_:
-                open_ = False
-                continue
-            elif char == '$' and not open_:
-                open_ = True
-                if len(word) > 0: res += '\\text{' + word + '}'
-                word = ''
-                continue
-        
-            if open_:
-                res += char
-            else:
-                word += char
+        self.latex = _parse_kaxe_text(text)
+        self._mathtext = _get_mathtext(self.latex, self.fontSize, self.color)
 
-        if len(word) > 0: res += '\\text{' + word + '}'
-
-        text = res
-
-        # make pil image
-        key = str(text), fontSize, tuple(color)
+        key = str(self.latex), fontSize, tuple(color)
         cachedImage = textImageCache.get(key)
         if cachedImage:
             pilImage = cachedImage
         else:
-            pilImage = MathText(text, self.fontSize, self.color).image
+            pilImage = self._mathtext.to_pil()
             textImageCache[key] = pilImage
-        
-        # width = pilImage.width 
-        # height = pilImage.height 
 
         self.img = pilImage.rotate(self.rotate, expand=True)
 
-        # newCenterFromTopLeft = np.array([[math.cos(self.rotate), -math.sin(self.rotate)], [math.sin(self.rotate), math.cos(self.rotate)]]) @ np.array((width/2, height/2))
-
         self.width = self.img.width
         self.height = self.img.height
-
-        # revert positions from rotation
-        # self.x -= newCenterFromTopLeft[0] - pilImage.width
-        # self.y -= newCenterFromTopLeft[1] - pilImage.height
 
         self.anchor_x = anchor_x
         self.anchor_y = anchor_y
@@ -143,6 +151,33 @@ class Text(Shape):
     def drawPillow(self, surface):
         [y] = flipHorizontal(surface, self.__center__[1] + self.height/2)
         blitImageToSurface(surface, self.img, (self.__leftTop__[0], y))
+
+    def drawSvg(self, doc):
+        kaxe_top = self.__center__[1] + self.height / 2
+        svg_top = doc.flip_y(kaxe_top)
+        rotate_center = (
+            self.__leftTop__[0] + self.width / 2,
+            svg_top + self.height / 2,
+        )
+
+        if hasattr(self._mathtext, "scene"):
+            doc.add_fondi_scene(
+                self._mathtext.scene(),
+                self.__leftTop__[0],
+                svg_top,
+                rotate=self.rotate,
+                rotate_center=rotate_center,
+            )
+            return
+
+        doc.add_image(
+            self.img,
+            self.__leftTop__[0],
+            kaxe_top,
+            y_coord="top",
+            rotate=self.rotate,
+            rotate_center=rotate_center,
+        )
 
 
     def push(self, x, y):

--- a/src/kaxe/core/text.py
+++ b/src/kaxe/core/text.py
@@ -11,6 +11,22 @@ mathtextCache = {}
 maxTextCacheSize = 100
 
 
+def _cache_get(cache: dict, key):
+    if key not in cache:
+        return None
+    value = cache.pop(key)
+    cache[key] = value
+    return value
+
+
+def _cache_set(cache: dict, key, value, max_size=maxTextCacheSize):
+    if key in cache:
+        cache.pop(key)
+    elif len(cache) >= max_size:
+        cache.pop(next(iter(cache)))
+    cache[key] = value
+
+
 def _parse_kaxe_text(text: str) -> str:
     """Translate kaxe $math$ syntax to fondi LaTeX string."""
     res = ''
@@ -39,11 +55,11 @@ def _parse_kaxe_text(text: str) -> str:
 
 def _get_mathtext(latex: str, fontSize: int, color: tuple) -> MathText:
     key = str(latex), fontSize, tuple(color)
-    cached = mathtextCache.get(key)
+    cached = _cache_get(mathtextCache, key)
     if cached is not None:
         return cached
     mt = MathText(latex, fontSize, color)
-    mathtextCache[key] = mt
+    _cache_set(mathtextCache, key, mt)
     return mt
 
 
@@ -75,12 +91,12 @@ class Text(Shape):
         self._mathtext = _get_mathtext(self.latex, self.fontSize, self.color)
 
         key = str(self.latex), fontSize, tuple(color)
-        cachedImage = textImageCache.get(key)
+        cachedImage = _cache_get(textImageCache, key)
         if cachedImage:
             pilImage = cachedImage
         else:
             pilImage = self._mathtext.to_pil()
-            textImageCache[key] = pilImage
+            _cache_set(textImageCache, key, pilImage)
 
         self.img = pilImage.rotate(self.rotate, expand=True)
 

--- a/src/kaxe/core/window.py
+++ b/src/kaxe/core/window.py
@@ -7,7 +7,7 @@ import logging
 from .styles import *
 from .legend import LegendBox
 from .shapes import shapes
-from .svg import SvgDocument, infer_format
+from .svg import SvgDocument, infer_format, is_file_path
 from PIL import Image
 import tqdm
 from random import randint
@@ -456,7 +456,7 @@ class Window(AttrObject):
             if self.showProgressBar: pbar.update()
 
         if fname is not None:
-            if isinstance(fname, str):
+            if is_file_path(fname):
                 surface.save(fname)
             else:
                 surface.save(fname, format="png")
@@ -485,7 +485,7 @@ class Window(AttrObject):
         xml = doc.serialize()
 
         if fname is not None:
-            if isinstance(fname, str):
+            if is_file_path(fname):
                 with open(fname, 'w', encoding='utf-8') as f:
                     f.write(xml)
             else:
@@ -529,7 +529,10 @@ class Window(AttrObject):
 
         if fmt == "png" and self.__bakedImage__:
             logging.log(0, 'Using cached plot window')
-            self.__bakedImage__.save(fname)
+            if is_file_path(fname):
+                self.__bakedImage__.save(fname)
+            else:
+                self.__bakedImage__.save(fname, format="png")
             return
 
         totStartTime = time.time()
@@ -539,7 +542,7 @@ class Window(AttrObject):
 
         if fmt == "png":
             if fname is not None:
-                if isinstance(fname, str):
+                if is_file_path(fname):
                     result.save(fname)
                 else:
                     result.save(fname, format="png")

--- a/src/kaxe/core/window.py
+++ b/src/kaxe/core/window.py
@@ -1,12 +1,13 @@
 
 from io import BytesIO
 import time
-from typing import Union
+from typing import Union, Optional
 from .helper import *
 import logging
 from .styles import *
 from .legend import LegendBox
 from .shapes import shapes
+from .svg import SvgDocument, infer_format
 from PIL import Image
 import tqdm
 from random import randint
@@ -88,6 +89,7 @@ class Window(AttrObject):
         
         self.__included__ = []
         self.__bakedImage__ = False
+        self.__baked__ = False
 
         self.legendbox = LegendBox()
         self.offset = [0,0]
@@ -370,6 +372,9 @@ class Window(AttrObject):
 
     # baking
     def __bake__(self):
+        if getattr(self, '__baked__', False):
+            return
+
         # finish making plot
         # fit "plot" into window 
         startTime = time.time()        
@@ -450,12 +455,11 @@ class Window(AttrObject):
             
             if self.showProgressBar: pbar.update()
 
-        if fname == None:
-            pass
-        elif fname is str:
-            surface.save(fname)
-        else:
-            surface.save(fname, format="png")
+        if fname is not None:
+            if isinstance(fname, str):
+                surface.save(fname)
+            else:
+                surface.save(fname, format="png")
 
         if self.showProgressBar: pbar.close()
         if self.printDebugInfo: logging.info('Painted in {}s'.format(str(round(time.time() - startTime, 4))))
@@ -463,14 +467,44 @@ class Window(AttrObject):
         return surface
 
 
-    def __paint__(self, *args, **kwargs):
-        
-        if True: # self.engine == 'PILLOW':
-            return self.__pillowPaint__(*args, **kwargs)
+    def __svgPaint__(self, fname=None) -> str:
+        startTime = time.time()
+        if self.showProgressBar: pbar = tqdm.tqdm(total=len(self.shapes), desc='Decorating SVG')
+
+        winSize = self.width+self.padding[0]+self.padding[2], self.height+self.padding[1]+self.padding[3]
+        doc = SvgDocument(winSize)
+
+        if self.getAttr('backgroundColor')[3] != 0:
+            background = shapes.Rectangle(0, 0, winSize[0], winSize[1], color=self.getAttr('backgroundColor'))
+            background.draw(doc)
+
+        for shape in self.shapes:
+            shape.draw(doc)
+            if self.showProgressBar: pbar.update()
+
+        xml = doc.serialize()
+
+        if fname is not None:
+            if isinstance(fname, str):
+                with open(fname, 'w', encoding='utf-8') as f:
+                    f.write(xml)
+            else:
+                fname.write(xml.encode('utf-8'))
+
+        if self.showProgressBar: pbar.close()
+        if self.printDebugInfo: logging.info('Painted SVG in {}s'.format(str(round(time.time() - startTime, 4))))
+
+        return xml
+
+
+    def __paint__(self, fname=None, format: str = "png"):
+        if format == "svg":
+            return self.__svgPaint__(fname)
+        return self.__pillowPaint__(fname)
 
 
     # save and show    
-    def save(self, fname:Union[str, BytesIO]):
+    def save(self, fname:Union[str, BytesIO], format:Optional[str]=None):
         """
         Save the current window image to a file.
         
@@ -479,16 +513,21 @@ class Window(AttrObject):
         
         Parameters
         ----------
-        fname : str | BytesIO
+        fname : str | BytesIO
             The filename where the image will be saved or a BytesIO object to save the image in memory.
+        format : str, optional
+            Output format: ``"png"`` or ``"svg"``. Inferred from ``fname`` extension when omitted.
         
         Examples
         --------
         >>> plt.save( path/where/image/saved.png )
+        >>> plt.save( path/where/image/saved.svg )
 
         """
 
-        if self.__bakedImage__:
+        fmt = infer_format(fname, format)
+
+        if fmt == "png" and self.__bakedImage__:
             logging.log(0, 'Using cached plot window')
             self.__bakedImage__.save(fname)
             return
@@ -496,7 +535,15 @@ class Window(AttrObject):
         totStartTime = time.time()
 
         self.__bake__()
-        self.__bakedImage__ = self.__paint__(fname)
+        result = self.__paint__(fname if fmt == "svg" else None, format=fmt)
+
+        if fmt == "png":
+            if fname is not None:
+                if isinstance(fname, str):
+                    result.save(fname)
+                else:
+                    result.save(fname, format="png")
+            self.__bakedImage__ = result
         
         if self.printDebugInfo:
             logging.info('Total time to save {}s'.format(str(round(time.time() - totStartTime, 4))))

--- a/tests/cases/test_svg_export.py
+++ b/tests/cases/test_svg_export.py
@@ -1,0 +1,121 @@
+"""
+SVG export tests for 2D plots.
+"""
+
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from io import BytesIO
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import kaxe
+from runner import unit
+
+
+SVG_NS = "http://www.w3.org/2000/svg"
+
+
+def _parse_svg(content: str) -> ET.Element:
+    root = ET.fromstring(content)
+    assert root.tag.endswith("svg") or root.tag == "svg"
+    return root
+
+
+def _local_tag(tag: str) -> str:
+    return tag.split("}")[-1] if "}" in tag else tag
+
+
+def _collect_tags(root: ET.Element) -> set[str]:
+    tags = {_local_tag(root.tag)}
+    for el in root.iter():
+        tags.add(_local_tag(el.tag))
+    return tags
+
+
+@unit()
+def test_svg_smoke_parse():
+    plot = kaxe.Plot([-5, 5, -5, 5])
+    plot.add(kaxe.Function2D(lambda x: x**2 - 4))
+    plot.showProgressBar = False
+    plot.printDebugInfo = False
+
+    with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as tmp:
+        path = tmp.name
+
+    try:
+        plot.save(path)
+        content = Path(path).read_text(encoding="utf-8")
+        root = _parse_svg(content)
+        assert root.get("width") is not None
+        assert root.get("height") is not None
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+@unit()
+def test_svg_structure_has_curve_and_axes():
+    plot = kaxe.Plot([-5, 5, -5, 5])
+    plot.add(kaxe.Function2D(lambda x: x**2 - 4))
+    plot.showProgressBar = False
+    plot.printDebugInfo = False
+
+    buf = BytesIO()
+    plot.save(buf, format="svg")
+    content = buf.getvalue().decode("utf-8")
+    tags = _collect_tags(_parse_svg(content))
+
+    assert "polyline" in tags or "path" in tags or "line" in tags
+    assert "line" in tags
+
+
+@unit()
+def test_svg_png_then_svg_not_cached():
+    plot = kaxe.Plot([-3, 3, -3, 3])
+    plot.add(kaxe.Function2D(lambda x: x))
+    plot.showProgressBar = False
+    plot.printDebugInfo = False
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        png_path = Path(tmpdir) / "plot.png"
+        svg_path = Path(tmpdir) / "plot.svg"
+
+        plot.save(str(png_path))
+        assert png_path.exists()
+
+        plot.save(str(svg_path))
+        content = svg_path.read_text(encoding="utf-8")
+        root = _parse_svg(content)
+        assert _local_tag(root.tag) == "svg"
+
+
+@unit()
+def test_svg_vector_text_labels():
+    plot = kaxe.Plot([-3, 3, -2, 5])
+    plot.add(kaxe.Function2D(lambda x: x**2))
+    plot.showProgressBar = False
+    plot.printDebugInfo = False
+
+    buf = BytesIO()
+    plot.save(buf, format="svg")
+    content = buf.getvalue().decode("utf-8")
+    tags = _collect_tags(_parse_svg(content))
+
+    assert "text" in tags
+    assert "style" in tags
+
+
+@unit()
+def test_svg_chart_pie():
+    chart = kaxe.Pie()
+    chart.add(5.0, legend="a", label="5")
+    chart.add(3.0, legend="b", label="3")
+    chart.showProgressBar = False
+    chart.printDebugInfo = False
+
+    buf = BytesIO()
+    chart.save(buf, format="svg")
+    tags = _collect_tags(_parse_svg(buf.getvalue().decode("utf-8")))
+
+    assert "path" in tags


### PR DESCRIPTION
Vector SVG output alongside PNG for standard 2D plots and charts, with fondi-powered math labels and embedded fonts.